### PR TITLE
Updated Dockerfiles for downloading from Github

### DIFF
--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -1,23 +1,19 @@
 FROM alpine:3.2
 
-RUN ALPINE_GLIBC_VERSION="2.23-r2" && \
-    ALPINE_GLIBC_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$ALPINE_GLIBC_VERSION" && \
-    GLIBC_PKG="glibc-$ALPINE_GLIBC_VERSION.apk" && \
-    GLIBC_BIN_PKG="glibc-bin-$ALPINE_GLIBC_VERSION.apk" && \
-    GLIBC_I18N_PKG="glibc-i18n-$ALPINE_GLIBC_VERSION.apk" && \
-    DOCKERIZE_VERSION="0.2.0" && \
-    DOCKERIZE_URL="https://github.com/jwilder/dockerize/releases/download/v$DOCKERIZE_VERSION" && \
-    DOCKERIZE_PKG="dockerize-linux-amd64-v$DOCKERIZE_VERSION.tar.gz" && \
+RUN ALPINE_GLIBC_VERSION="latest" && \
+    ALPINE_GLIBC_REPO="sgerrand" && \
+    ALPINE_GLIBC_PROJ="alpine-pkg-glibc" && \
+    DOCKERIZE_VERSION="latest" && \
+    DOCKERIZE_REPO="jwilder" && \
+    DOCKERIZE_PROJ="dockerize" && \
     apk add --update -t deps wget ca-certificates curl bash && \
     cd /tmp && \
-    curl -L $ALPINE_GLIBC_URL//$GLIBC_PKG -o $GLIBC_PKG && \
-    curl -L $ALPINE_GLIBC_URL/$GLIBC_BIN_PKG -o $GLIBC_BIN_PKG && \
-    curl -L $ALPINE_GLIBC_URL/$GLIBC_I18N_PKG -o $GLIBC_I18N_PKG && \
-    apk add --allow-untrusted $GLIBC_PKG $GLIBC_BIN_PKG $GLIBC_I18N_PKG && \
+    wget $(curl -s https://api.github.com/repos/$ALPINE_GLIBC_REPO/$ALPINE_GLIBC_PROJ/releases/$ALPINE_GLIBC_VERSION | grep 'browser_' | egrep 'glibc-.*.apk' | cut -d\" -f4) && \
+    apk add --allow-untrusted glibc-*.apk && \
     /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true && \
     echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
-    curl -L $DOCKERIZE_URL/$DOCKERIZE_PKG -o $DOCKERIZE_PKG && \
-    tar -C /usr/local/bin -xzvf $DOCKERIZE_PKG && \
+    wget $(curl -s https://api.github.com/repos/$DOCKERIZE_REPO/$DOCKERIZE_PROJ/releases/$DOCKERIZE_VERSION | grep 'browser_' | egrep 'amd64-.*.tar.gz' | cut -d\" -f4) && \
+    tar -C /usr/local/bin -xzvf *-linux-amd64-*.tar.gz && \
     apk del --purge deps glibc-i18n && \
     apk add --update wget ca-certificates curl bash && \
     rm -rf /tmp/* /var/cache/apk/*

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -1,23 +1,19 @@
 FROM alpine:3.3
 
-RUN ALPINE_GLIBC_VERSION="2.23-r2" && \
-    ALPINE_GLIBC_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$ALPINE_GLIBC_VERSION" && \
-    GLIBC_PKG="glibc-$ALPINE_GLIBC_VERSION.apk" && \
-    GLIBC_BIN_PKG="glibc-bin-$ALPINE_GLIBC_VERSION.apk" && \
-    GLIBC_I18N_PKG="glibc-i18n-$ALPINE_GLIBC_VERSION.apk" && \
-    DOCKERIZE_VERSION="0.2.0" && \
-    DOCKERIZE_URL="https://github.com/jwilder/dockerize/releases/download/v$DOCKERIZE_VERSION" && \
-    DOCKERIZE_PKG="dockerize-linux-amd64-v$DOCKERIZE_VERSION.tar.gz" && \
+RUN ALPINE_GLIBC_VERSION="latest" && \
+    ALPINE_GLIBC_REPO="sgerrand" && \
+    ALPINE_GLIBC_PROJ="alpine-pkg-glibc" && \
+    DOCKERIZE_VERSION="latest" && \
+    DOCKERIZE_REPO="jwilder" && \
+    DOCKERIZE_PROJ="dockerize" && \
     apk add --update -t deps wget ca-certificates curl bash && \
     cd /tmp && \
-    curl -L $ALPINE_GLIBC_URL//$GLIBC_PKG -o $GLIBC_PKG && \
-    curl -L $ALPINE_GLIBC_URL/$GLIBC_BIN_PKG -o $GLIBC_BIN_PKG && \
-    curl -L $ALPINE_GLIBC_URL/$GLIBC_I18N_PKG -o $GLIBC_I18N_PKG && \
-    apk add --allow-untrusted $GLIBC_PKG $GLIBC_BIN_PKG $GLIBC_I18N_PKG && \
+    wget $(curl -s https://api.github.com/repos/$ALPINE_GLIBC_REPO/$ALPINE_GLIBC_PROJ/releases/$ALPINE_GLIBC_VERSION | grep 'browser_' | egrep 'glibc-.*.apk' | cut -d\" -f4) && \
+    apk add --allow-untrusted glibc-*.apk && \
     /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true && \
     echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
-    curl -L $DOCKERIZE_URL/$DOCKERIZE_PKG -o $DOCKERIZE_PKG && \
-    tar -C /usr/local/bin -xzvf $DOCKERIZE_PKG && \
+    wget $(curl -s https://api.github.com/repos/$DOCKERIZE_REPO/$DOCKERIZE_PROJ/releases/$DOCKERIZE_VERSION | grep 'browser_' | egrep 'amd64-.*.tar.gz' | cut -d\" -f4) && \
+    tar -C /usr/local/bin -xzvf *-linux-amd64-*.tar.gz && \
     apk del --purge deps glibc-i18n && \
     apk add --update wget ca-certificates curl bash && \
     rm -rf /tmp/* /var/cache/apk/*

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -1,23 +1,19 @@
 FROM alpine:3.4
 
-RUN ALPINE_GLIBC_VERSION="2.23-r2" && \
-    ALPINE_GLIBC_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$ALPINE_GLIBC_VERSION" && \
-    GLIBC_PKG="glibc-$ALPINE_GLIBC_VERSION.apk" && \
-    GLIBC_BIN_PKG="glibc-bin-$ALPINE_GLIBC_VERSION.apk" && \
-    GLIBC_I18N_PKG="glibc-i18n-$ALPINE_GLIBC_VERSION.apk" && \
-    DOCKERIZE_VERSION="0.2.0" && \
-    DOCKERIZE_URL="https://github.com/jwilder/dockerize/releases/download/v$DOCKERIZE_VERSION" && \
-    DOCKERIZE_PKG="dockerize-linux-amd64-v$DOCKERIZE_VERSION.tar.gz" && \
+RUN ALPINE_GLIBC_VERSION="latest" && \
+    ALPINE_GLIBC_REPO="sgerrand" && \
+    ALPINE_GLIBC_PROJ="alpine-pkg-glibc" && \
+    DOCKERIZE_VERSION="latest" && \
+    DOCKERIZE_REPO="jwilder" && \
+    DOCKERIZE_PROJ="dockerize" && \
     apk add --update -t deps wget ca-certificates curl bash && \
     cd /tmp && \
-    curl -L $ALPINE_GLIBC_URL//$GLIBC_PKG -o $GLIBC_PKG && \
-    curl -L $ALPINE_GLIBC_URL/$GLIBC_BIN_PKG -o $GLIBC_BIN_PKG && \
-    curl -L $ALPINE_GLIBC_URL/$GLIBC_I18N_PKG -o $GLIBC_I18N_PKG && \
-    apk add --allow-untrusted $GLIBC_PKG $GLIBC_BIN_PKG $GLIBC_I18N_PKG && \
+    wget $(curl -s https://api.github.com/repos/$ALPINE_GLIBC_REPO/$ALPINE_GLIBC_PROJ/releases/$ALPINE_GLIBC_VERSION | grep 'browser_' | egrep 'glibc-.*.apk' | cut -d\" -f4) && \
+    apk add --allow-untrusted glibc-*.apk && \
     /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true && \
     echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
-    curl -L $DOCKERIZE_URL/$DOCKERIZE_PKG -o $DOCKERIZE_PKG && \
-    tar -C /usr/local/bin -xzvf $DOCKERIZE_PKG && \
+    wget $(curl -s https://api.github.com/repos/$DOCKERIZE_REPO/$DOCKERIZE_PROJ/releases/$DOCKERIZE_VERSION | grep 'browser_' | egrep 'amd64-.*.tar.gz' | cut -d\" -f4) && \
+    tar -C /usr/local/bin -xzvf *-linux-amd64-*.tar.gz && \
     apk del --purge deps glibc-i18n && \
     apk add --update wget ca-certificates curl bash && \
     rm -rf /tmp/* /var/cache/apk/*


### PR DESCRIPTION
On the old version I was no longer able to download directly from Github. I added a loop to grab the current unique url and download the requested files for glibc and Dockerize.
